### PR TITLE
Make the radio actually usable for ox_inventory

### DIFF
--- a/resource/server/server.lua
+++ b/resource/server/server.lua
@@ -16,7 +16,7 @@ if server.core == 'esx' then
 	local ESX = exports.es_extended:getSharedObject()
 	server.getPlayers = ESX.GetExtendedPlayers
 
-	if not ac.useCommand and not hasResource('ox_inventory') then
+	if not ac.useCommand and hasResource('ox_inventory') then
 		ESX.RegisterUsableItem('radio', function(source)
 			TriggerClientEvent('ac_radio:openRadio', source)
 		end)


### PR DESCRIPTION
This allows you to skip adding exports to an item inside `ox_inventory`
Just turn the check whether you don't have the ox_inventory resource into check whether you have the resource.