### PR TITLE
Added support for ace perms

### DIFF
--- a/modules/server/framework/aceperms.lua
+++ b/modules/server/framework/aceperms.lua
@@ -4,23 +4,23 @@ local Config = require 'config'
 Citizen.CreateThread(function()
     for frequency, allowed in pairs(Config.restrictedChannels) do
         Voice:addChannelCheck(tonumber(frequency), function(playerId)
-            if type(allowed) == 'table' then
-                for _, ace in pairs(allowed) do
-                    if IsPlayerAceAllowed(playerId, ace) then
-                        lib.notify(playerId, {
-                            type = 'success',
-                            description = locale('channel_join', frequency + 0.0),
-                        })
-                        return true
-                    end
-                end
-            else
+            if type(allowed) == 'string' then
                 if IsPlayerAceAllowed(playerId, allowed) then
                     lib.notify(playerId, {
                         type = 'success',
                         description = locale('channel_join', frequency + 0.0),
                     })
                     return true
+                end
+            elseif type(allowed) == 'table' then
+                for _, ace in pairs(allowed) do
+                    if type(ace) == 'string' and IsPlayerAceAllowed(playerId, ace) then
+                        lib.notify(playerId, {
+                            type = 'success',
+                            description = locale('channel_join', frequency + 0.0),
+                        })
+                        return true
+                    end
                 end
             end
 

--- a/modules/server/framework/aceperms.lua
+++ b/modules/server/framework/aceperms.lua
@@ -1,0 +1,35 @@
+local Voice = exports['pma-voice']
+local Config = require 'config'
+
+Citizen.CreateThread(function()
+    for frequency, allowed in pairs(Config.restrictedChannels) do
+        Voice:addChannelCheck(tonumber(frequency), function(playerId)
+            if type(allowed) == 'table' then
+                for _, ace in pairs(allowed) do
+                    if IsPlayerAceAllowed(playerId, ace) then
+                        lib.notify(playerId, {
+                            type = 'success',
+                            description = locale('channel_join', frequency + 0.0),
+                        })
+                        return true
+                    end
+                end
+            else
+                if IsPlayerAceAllowed(playerId, allowed) then
+                    lib.notify(playerId, {
+                        type = 'success',
+                        description = locale('channel_join', frequency + 0.0),
+                    })
+                    return true
+                end
+            end
+
+            lib.notify(playerId, {
+                type = 'error',
+                description = locale('channel_unavailable'),
+            })
+
+            return false
+        end)
+    end
+end)

--- a/modules/server/framework/esx.lua
+++ b/modules/server/framework/esx.lua
@@ -12,7 +12,7 @@ AddEventHandler('esx:playerLogout', function(playerId)
     Player(playerId).state:set('ac:hasRadioProp', false, true)
 end)
 
-CreateThread(function()
+Citizen.CreateThread(function()
     if Config.useUsableItem and not Utils.hasExport('ox_inventory.Items') then
         ESX.RegisterUsableItem('radio', function(playerId)
             TriggerClientEvent('ac_radio:openRadio', playerId)

--- a/modules/server/framework/ox.lua
+++ b/modules/server/framework/ox.lua
@@ -13,7 +13,7 @@ AddEventHandler('ox:playerLogout', function(playerId)
     Player(playerId).state:set('ac:hasRadioProp', false, true)
 end)
 
-CreateThread(function()
+Citizen.CreateThread(function()
     for frequency, allowed in pairs(Config.restrictedChannels) do
         Voice:addChannelCheck(tonumber(frequency), function(playerId)
             local player = Ox.GetPlayer(playerId)

--- a/modules/server/framework/qb.lua
+++ b/modules/server/framework/qb.lua
@@ -12,7 +12,7 @@ AddEventHandler('QBCore:Server:OnPlayerUnload', function(playerId)
     Player(playerId).state:set('ac:hasRadioProp', false, true)
 end)
 
-CreateThread(function()
+Citizen.CreateThread(function()
     if Config.useUsableItem and not Utils.hasExport('ox_inventory.Items') then
         QB.Functions.CreateUseableItem('radio', function(playerId)
             TriggerClientEvent('ac_radio:openRadio', playerId)

--- a/modules/server/main.lua
+++ b/modules/server/main.lua
@@ -18,5 +18,7 @@ SetTimeout(0, function()
         require 'modules.server.framework.esx'
     elseif Utils.hasExport('qb-core.GetCoreObject') then
         require 'modules.server.framework.qb'
+    else
+        require 'modules.server.framework.aceperms'
     end
 end)

--- a/modules/server/main.lua
+++ b/modules/server/main.lua
@@ -11,14 +11,14 @@ SetConvarReplicated('voice_enableSubmix', Config.radioEffect and '1' or '0')
 SetConvarReplicated('voice_enableRadioAnim', Config.radioAnimation and '1' or '0')
 SetConvarReplicated('voice_defaultRadio', Config.radioTalkKey)
 
-SetTimeout(0, function()
+Citizen.SetTimeout(0, function()
     if Utils.hasExport('ox_core.GetPlayer') then
         require 'modules.server.framework.ox'
     elseif Utils.hasExport('es_extended.getSharedObject') then
         require 'modules.server.framework.esx'
     elseif Utils.hasExport('qb-core.GetCoreObject') then
         require 'modules.server.framework.qb'
-    else
-        require 'modules.server.framework.aceperms'
     end
+
+    require 'modules.server.framework.aceperms'
 end)


### PR DESCRIPTION
This is a simple change that adds support for ACE permissions and works as shown below.

In the config where the restrictedChannels are located, it looks very similar if you're using ACE permissions as seen below:

```lua
restrictedChannels = {
    [1] = 'LEO',
    [2] = {
        'LEO',
        'EMS',
        'ADMIN'
    }
}
```

Basically, [1] is still the frequency and the string it's equal to is the ACE permission you must have to join said channel. Now, [2] is the same except it allows for all of the ACE permissions to join that same channel, just in case you need multiple ACE permissions to join the same channel.